### PR TITLE
add O3 flag to remove warning

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -80,7 +80,7 @@ dependencies = [
  "encode_unicode",
  "libc",
  "once_cell",
- "unicode-width 0.2.0",
+ "unicode-width",
  "windows-sys",
 ]
 
@@ -211,7 +211,7 @@ dependencies = [
  "console",
  "number_prefix",
  "portable-atomic",
- "unicode-width 0.2.0",
+ "unicode-width",
  "web-time",
 ]
 
@@ -577,7 +577,7 @@ dependencies = [
  "skidder",
  "slab",
  "tree-house-bindings",
- "unicode-width 0.1.12",
+ "unicode-width",
 ]
 
 [[package]]
@@ -612,12 +612,6 @@ name = "unicode-ident"
 version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a210d160f08b701c8721ba1c726c11662f877ea6b7094007e1ca9a1041945034"
-
-[[package]]
-name = "unicode-width"
-version = "0.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68f5e5f3158ecfd4b8ff6fe086db7c8467a2dfdac97fe420f2b7c4aa97af66d6"
 
 [[package]]
 name = "unicode-width"

--- a/bindings/build.rs
+++ b/bindings/build.rs
@@ -22,6 +22,7 @@ fn main() {
         .flag_if_supported("-Wshadow")
         .flag_if_supported("-Wno-unused-parameter")
         .flag_if_supported("-Wno-incompatible-pointer-types")
+        .flag_if_supported("-O3")
         .include(&src_path)
         .include(&include_path)
         .define("_POSIX_C_SOURCE", "200112L")

--- a/highlighter/Cargo.toml
+++ b/highlighter/Cargo.toml
@@ -23,7 +23,7 @@ hashbrown = { version = "0.15" }
 regex = "1"
 regex-cursor = "0.1"
 slab = "0.4"
-unicode-width = { version = "=0.1.12", optional = true }
+unicode-width = { version = "0.2", optional = true }
 pretty_assertions = { version = "1.4.0", optional = true }
 kstring = "2.0"
 


### PR DESCRIPTION
Hey there was a build warning that this removes, this is the warning

```rs
   Compiling tree-house-bindings v0.1.0-beta.1 (/home/redhawk/code/test/tree-house/bindings)
warning: tree-house-bindings@0.1.0-beta.1: In file included from /nix/store/5djq7mrpqv8kzn2xi22y5d8ww7rsix82-glibc-2.40-66-dev/include/bits/libc-header-start.h:33,
warning: tree-house-bindings@0.1.0-beta.1:                  from /nix/store/5djq7mrpqv8kzn2xi22y5d8ww7rsix82-glibc-2.40-66-dev/include/stdio.h:28,
warning: tree-house-bindings@0.1.0-beta.1:                  from /home/redhawk/code/test/tree-house/bindings/vendor/src/./alloc.h:9,
warning: tree-house-bindings@0.1.0-beta.1:                  from /home/redhawk/code/test/tree-house/bindings/vendor/src/./alloc.c:1,
warning: tree-house-bindings@0.1.0-beta.1:                  from /home/redhawk/code/test/tree-house/bindings/vendor/src/lib.c:1:
warning: tree-house-bindings@0.1.0-beta.1: /nix/store/5djq7mrpqv8kzn2xi22y5d8ww7rsix82-glibc-2.40-66-dev/include/features.h:422:4: warning: #warning _FORTIFY_SOURCE requires compiling with optimization (-O) [-Wcpp]
warning: tree-house-bindings@0.1.0-beta.1:   422 | #  warning _FORTIFY_SOURCE requires compiling with optimization (-O)
warning: tree-house-bindings@0.1.0-beta.1:       |    ^~~~~~~
   Compiling tree-house v0.1.0-beta.1 (/home/redhawk/code/test/tree-house/highlighter)

```

I also changed the version of unicode so cargo could resolve a dependency conflict. 