### PR TITLE
feat: add `Syntax::layers_for_byte_range`

### DIFF
--- a/highlighter/src/lib.rs
+++ b/highlighter/src/lib.rs
@@ -170,21 +170,17 @@ impl Syntax {
             .descendant_for_byte_range(start, end)
     }
 
-    /// # Returns
-    ///
-    /// The smallest injection layer that fully includes the range `start..=end`.
+    /// Finds the smallest injection layer that fully includes the range `start..=end`.
     pub fn layer_for_byte_range(&self, start: u32, end: u32) -> Layer {
         self.layers_for_byte_range(start, end)
             .last()
             .expect("always includes the root layer")
     }
 
-    /// # Returns
-    ///
-    /// A iterator of layers which **fully include** the byte range `start..=end`,
+    /// Returns an iterator of layers which **fully include** the byte range `start..=end`,
     /// in decreasing order based on the size of each layer.
     ///
-    /// The first layer is the `root` layer.
+    /// The first layer is always the `root` layer.
     pub fn layers_for_byte_range(&self, start: u32, end: u32) -> impl Iterator<Item = Layer> + '_ {
         let mut parent_injection_layer = self.root;
 

--- a/highlighter/src/lib.rs
+++ b/highlighter/src/lib.rs
@@ -185,11 +185,7 @@ impl Syntax {
     /// in decreasing order based on the size of each layer.
     ///
     /// The first layer is the `root` layer.
-    pub fn layers_for_byte_range(
-        &self,
-        start: u32,
-        end: u32,
-    ) -> impl Iterator<Item = Layer> + use<'_> {
+    pub fn layers_for_byte_range(&self, start: u32, end: u32) -> impl Iterator<Item = Layer> {
         let mut parent_injection_layer = self.root;
 
         std::iter::from_fn(move || {

--- a/highlighter/src/lib.rs
+++ b/highlighter/src/lib.rs
@@ -176,7 +176,7 @@ impl Syntax {
     pub fn layer_for_byte_range(&self, start: u32, end: u32) -> Layer {
         self.layers_for_byte_range(start, end)
             .last()
-            .unwrap_or(self.root)
+            .expect("always includes the root layer")
     }
 
     /// # Returns
@@ -188,7 +188,7 @@ impl Syntax {
     pub fn layers_for_byte_range(&self, start: u32, end: u32) -> impl Iterator<Item = Layer> + '_ {
         let mut parent_injection_layer = self.root;
 
-        std::iter::from_fn(move || {
+        std::iter::once(self.root).chain(std::iter::from_fn(move || {
             let layer = &self.layers[parent_injection_layer.idx()];
 
             let injection_at_start = layer.injection_at_byte_idx(start)?;
@@ -201,7 +201,7 @@ impl Syntax {
 
                 injection_at_start.layer
             })
-        })
+        }))
     }
 
     pub fn walk(&self) -> TreeCursor {

--- a/highlighter/src/lib.rs
+++ b/highlighter/src/lib.rs
@@ -185,7 +185,7 @@ impl Syntax {
     /// in decreasing order based on the size of each layer.
     ///
     /// The first layer is the `root` layer.
-    pub fn layers_for_byte_range(&self, start: u32, end: u32) -> impl Iterator<Item = Layer> {
+    pub fn layers_for_byte_range(&self, start: u32, end: u32) -> impl Iterator<Item = Layer> + '_ {
         let mut parent_injection_layer = self.root;
 
         std::iter::from_fn(move || {

--- a/highlighter/src/lib.rs
+++ b/highlighter/src/lib.rs
@@ -176,7 +176,7 @@ impl Syntax {
     pub fn layer_for_byte_range(&self, start: u32, end: u32) -> Layer {
         self.layers_for_byte_range(start, end)
             .last()
-            .expect("`self.root` is the first layer")
+            .unwrap_or(self.root)
     }
 
     /// # Returns

--- a/highlighter/src/tests.rs
+++ b/highlighter/src/tests.rs
@@ -236,23 +236,7 @@ fn layers() {
 
     let input = "/// Says hello.
 ///
-/// Some html, this is *markdown-inline* markdown
-/// 
-/// ```html
-/// <div>
-///  <p>Hello</p>
-///  <style>
-///   p {
-///     /* css comment */
-///     background-color: red;
-///   }
-///  </style>
-///  <script>
-///   // javascript comment
-///   javascript_function();
-///  </script>
-/// </div>
-/// ```
+/// this is *markdown-inline* markdown
 /// 
 /// # Example
 ///
@@ -312,37 +296,6 @@ pub fn hello() {}";
 
     // Paragraph in the rust documentation
     assert_injection("markdown-inline", &["rust", "markdown", "markdown-inline"]);
-
-    // TODO: Enable these tests
-    //
-    // Currently, the Syntax does not have any "css", "javascript" or "comment"
-    // in it, even though the injection queries are supposed to inject these languages
-    //
-    // dbg!(syntax
-    //     .layers
-    //     .into_iter()
-    //     .map(|(_, layer)| loader
-    //         .languages
-    //         .get_index(layer.language.idx())
-    //         .unwrap()
-    //         .0
-    //         .clone())
-    //     .collect::<Vec<_>>());
-
-    // Injections past "html" don't get recognized
-    // assert_injection("background-color", &["rust", "markdown", "html", "css"]);
-    // assert_injection(
-    //     "javascript_function",
-    //     &["rust", "markdown", "html", "javascript"],
-    // );
-    // assert_injection(
-    //     "css comment",
-    //     &["rust", "markdown", "html", "css", "comment"],
-    // );
-    // assert_injection(
-    //     "javascript comment",
-    //     &["rust", "markdown", "html", "javascript", "comment"],
-    // );
 }
 
 #[test]

--- a/highlighter/src/tests.rs
+++ b/highlighter/src/tests.rs
@@ -13,7 +13,7 @@ use crate::config::{LanguageConfig, LanguageLoader};
 use crate::fixtures::{check_highlighter_fixture, check_injection_fixture};
 use crate::highlighter::Highlight;
 use crate::injections_query::InjectionLanguageMarker;
-use crate::Language;
+use crate::{Language, Layer};
 
 static GRAMMARS: Lazy<Vec<PathBuf>> = Lazy::new(|| {
     let skidder_config = skidder_config();
@@ -228,6 +228,122 @@ fn injection_fixture(loader: &TestLanguageLoader, fixture: impl AsRef<Path>) {
 fn highlight() {
     let loader = TestLanguageLoader::new();
     highlight_fixture(&loader, "highlighter/hello_world.rs");
+}
+
+#[test]
+fn layers() {
+    let loader = TestLanguageLoader::new();
+
+    let input = "/// Says hello.
+///
+/// Some html, this is *markdown-inline* markdown
+/// 
+/// ```html
+/// <div>
+///  <p>Hello</p>
+///  <style>
+///   p {
+///     /* css comment */
+///     background-color: red;
+///   }
+///  </style>
+///  <script>
+///   // javascript comment
+///   javascript_function();
+///  </script>
+/// </div>
+/// ```
+/// 
+/// # Example
+///
+/// ```rust
+/// fn add(left: usize, right: usize) -> usize {
+///     left + right
+/// }
+/// ```
+pub fn hello() {}";
+
+    let syntax = crate::Syntax::new(
+        ropey::RopeSlice::from(input),
+        loader.get("rust"),
+        std::time::Duration::from_secs(60),
+        &loader,
+    )
+    .unwrap();
+
+    let assert_injection = |snippet: &str, expected: &[&str]| {
+        assert!(!expected.is_empty(), "all layers have at least 1 injection");
+
+        let layer_lang_name = |layer: Layer| {
+            loader
+                .languages
+                .get_index(syntax.layer(layer).language.idx())
+                .unwrap()
+                .0
+                .clone()
+        };
+
+        let snippet_start = input.find(snippet).unwrap() as u32;
+        let snippet_end = snippet_start + snippet.len() as u32;
+
+        let layers = syntax
+            .layers_for_byte_range(snippet_start, snippet_end)
+            .into_iter()
+            .map(layer_lang_name)
+            .collect::<Vec<_>>();
+
+        assert_eq!(&layers, expected, r#"snippet: "{snippet}""#);
+
+        let layer = syntax.layer_for_byte_range(snippet_start, snippet_end);
+        assert_eq!(
+            &layer_lang_name(layer),
+            expected.last().unwrap(),
+            "last layer is the smallest fully encompassing layer"
+        );
+    };
+
+    // Rust function in a code block in the rust documentation
+    assert_injection("fn add(left: usize, ri", &["rust", "markdown", "rust"]);
+
+    // Markdown heading  `# Example`
+    assert_injection("# Example", &["rust", "markdown"]);
+
+    // Outer-most Rust function `hello`
+    assert_injection("pub fn hello() {}", &["rust"]);
+
+    // Paragraph in the rust documentation
+    assert_injection("markdown-inline", &["rust", "markdown", "markdown-inline"]);
+
+    // TODO: Enable these tests
+    //
+    // Currently, the Syntax does not have any "css", "javascript" or "comment"
+    // in it, even though the injection queries are supposed to inject these languages
+    //
+    // dbg!(syntax
+    //     .layers
+    //     .into_iter()
+    //     .map(|(_, layer)| loader
+    //         .languages
+    //         .get_index(layer.language.idx())
+    //         .unwrap()
+    //         .0
+    //         .clone())
+    //     .collect::<Vec<_>>());
+
+    // Injections past "html" don't get recognized
+    // assert_injection("background-color", &["rust", "markdown", "html", "css"]);
+    // assert_injection(
+    //     "javascript_function",
+    //     &["rust", "markdown", "html", "javascript"],
+    // );
+    // assert_injection(
+    //     "css comment",
+    //     &["rust", "markdown", "html", "css", "comment"],
+    // );
+    // assert_injection(
+    //     "javascript comment",
+    //     &["rust", "markdown", "html", "javascript", "comment"],
+    // );
 }
 
 #[test]

--- a/highlighter/src/tests.rs
+++ b/highlighter/src/tests.rs
@@ -288,7 +288,6 @@ pub fn hello() {}";
 
         let layers = syntax
             .layers_for_byte_range(snippet_start, snippet_end)
-            .into_iter()
             .map(layer_lang_name)
             .collect::<Vec<_>>();
 


### PR DESCRIPTION
When I tried to migrate the comment continuation PR (https://github.com/helix-editor/helix/pull/12759) to use the new tree-house bindings, I encountered a problem:

When continuing comments, we look at the smallest injection layer that includes the selection. This layer is the `comment` language itself, which has no tokens. We need to ignore it and try the next layer. But there's no way to do that currently

I think returning a list of layers from largest to smallest that include the byte range is a good API for tree-house

I updated my helix PR to make use of this PR: https://github.com/helix-editor/helix/blob/f07e6973fedb2fed4ff7f0e1a9d166bea7bedcab/helix-core/src/comment.rs#L58-L77

## Public API

```rs
impl Syntax {
    /// # Returns
    ///
    /// A list of layers which **fully include** the byte range `start..=end`,
    /// in decreasing order based on the size of each layer.
    ///
    /// The first layer is the `root` layer.
    pub fn layers_for_byte_range(&self, start: u32, end: u32) -> Iterator<Item = Layer>;
}
```

