### PR TITLE
feat: Allow specifying a file for injection queries

### DIFF
--- a/highlighter/src/fixtures.rs
+++ b/highlighter/src/fixtures.rs
@@ -140,7 +140,14 @@ pub fn roundtrip_highlighter_fixture<R: RangeBounds<usize>>(
     range: impl Fn(RopeSlice) -> R,
 ) -> String {
     let raw = strip_annotations(src, comment_prefix);
-    let syntax = Syntax::new(raw.slice(..), language, Duration::from_secs(60), loader).unwrap();
+    let syntax = Syntax::new(
+        raw.slice(..),
+        language,
+        Duration::from_secs(60),
+        loader,
+        None,
+    )
+    .unwrap();
     let range = range(raw.slice(..));
     highlighter_fixture(
         comment_prefix,
@@ -161,7 +168,14 @@ pub fn roundtrip_injection_fixture<R: RangeBounds<usize>>(
     range: impl Fn(RopeSlice) -> R,
 ) -> String {
     let raw = strip_annotations(src, comment_prefix);
-    let syntax = Syntax::new(raw.slice(..), language, Duration::from_secs(60), loader).unwrap();
+    let syntax = Syntax::new(
+        raw.slice(..),
+        language,
+        Duration::from_secs(60),
+        loader,
+        None,
+    )
+    .unwrap();
     let range = range(raw.slice(..));
     injections_fixture(
         comment_prefix,

--- a/highlighter/src/lib.rs
+++ b/highlighter/src/lib.rs
@@ -5,6 +5,7 @@ use slab::Slab;
 
 use std::fmt;
 use std::hash::{Hash, Hasher};
+use std::path::PathBuf;
 use std::time::Duration;
 use tree_sitter::{IncompatibleGrammarError, Node, Tree};
 
@@ -85,6 +86,8 @@ impl Language {
 pub struct Syntax {
     layers: Slab<LayerData>,
     root: Layer,
+    /// Path to the file which owns
+    path: Option<PathBuf>,
 }
 
 impl Syntax {
@@ -93,6 +96,7 @@ impl Syntax {
         language: Language,
         timeout: Duration,
         loader: &impl LanguageLoader,
+        path: Option<PathBuf>,
     ) -> Result<Self, Error> {
         let root_layer = LayerData {
             parse_tree: None,
@@ -113,6 +117,7 @@ impl Syntax {
         let mut syntax = Self {
             root: Layer(root as u32),
             layers,
+            path,
         };
 
         syntax.update(source, timeout, &[], loader).map(|_| syntax)


### PR DESCRIPTION
This PR allows specifying a file for which an injection is loaded.

See the [Helix PR](https://github.com/helix-editor/helix/pull/13549) which depends on this PR for more info. I'm really excited about this!

Note: The API I made to enable this is simply placeholder. What should it be changed to?