### PR TITLE
Fix: Rendering Rust->Markdown->Rust->Markdown no longer crashes

### DIFF
--- a/highlighter/src/query_iter.rs
+++ b/highlighter/src/query_iter.rs
@@ -282,6 +282,7 @@ where
                 .peek(self.layer_manager.src, &self.layer_manager.loader)
                 .filter(|matched_node| {
                     matched_node.node.start_byte() <= self.current_injection.range.end
+                        && matched_node.node.start_byte() >= self.current_injection.range.start
                 });
 
             match (next_match, next_injection) {


### PR DESCRIPTION
Closes helix-editor/helix#13569.

This change just makes sure that query nodes will only match if they are in the right range of bytes. It fixes our problem and passes the tests as they are. I can't think of any cases where the logic would be wrong, but am open to ideas or tests to write that could pass. I also didn't add a test because I'm not sure how the tests were created, but I think it would be good to add one to prevent a regression for this case.