### PR TITLE
add recursive walker

### DIFF
--- a/bindings/src/node.rs
+++ b/bindings/src/node.rs
@@ -95,6 +95,14 @@ impl<'tree> Node<'tree> {
         unsafe { ts_node_is_named(self.as_raw()) }
     }
 
+    /// Returns true if and only if this node is contained "inside" the given
+    /// input range, i.e. either start_new > start_old and end_new <= end_old OR
+    /// start_new >= start_old and end_new < end_old
+    pub fn is_contained_within(&self, range: Range<u32>) -> bool {
+        (self.start_byte() > range.start && self.end_byte() <= range.end)
+            || (self.start_byte() >= range.start && self.end_byte() < range.end)
+    }
+
     /// Check if this node is *missing*.
     ///
     /// Missing nodes are inserted by the parser in order to recover from

--- a/bindings/src/tree_cursor.rs
+++ b/bindings/src/tree_cursor.rs
@@ -77,7 +77,7 @@ impl<'tree> TreeCursor<'tree> {
         }
     }
 
-    pub fn reset(&mut self, node: Node<'tree>) {
+    pub fn reset(&mut self, node: &Node<'tree>) {
         unsafe { ts_tree_cursor_reset(&mut self.inner, node.as_raw()) }
     }
 
@@ -149,7 +149,7 @@ impl<'tree> Iterator for TreeRecursiveWalker<'tree> {
         }
 
         while let Some(queued) = self.queue.pop_front() {
-            self.cursor.reset(queued);
+            self.cursor.reset(&queued);
 
             if !self.cursor.goto_first_child() {
                 continue;

--- a/bindings/src/tree_cursor.rs
+++ b/bindings/src/tree_cursor.rs
@@ -1,5 +1,6 @@
 use ::std::os::raw;
 use std::cell::Cell;
+use std::collections::VecDeque;
 use std::ffi::{c_char, CStr};
 use std::marker::PhantomData;
 use std::{fmt, mem};
@@ -76,6 +77,10 @@ impl<'tree> TreeCursor<'tree> {
         }
     }
 
+    pub fn reset(&mut self, node: Node<'tree>) {
+        unsafe { ts_tree_cursor_reset(&mut self.inner, node.as_raw()) }
+    }
+
     pub fn node(&self) -> Node<'tree> {
         unsafe { Node::from_raw(ts_tree_cursor_current_node(&self.inner)).unwrap_unchecked() }
     }
@@ -106,6 +111,54 @@ impl Clone for TreeCursor<'_> {
             inner: unsafe { ts_tree_cursor_copy(&self.inner) },
             tree: PhantomData,
         }
+    }
+}
+
+impl<'tree> IntoIterator for &'tree mut TreeCursor<'tree> {
+    type Item = Node<'tree>;
+    type IntoIter = TreeRecursiveWalker<'tree>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        let mut queue = VecDeque::new();
+        let root = self.node();
+        queue.push_back(root.clone());
+
+        TreeRecursiveWalker {
+            cursor: self,
+            queue,
+            root,
+        }
+    }
+}
+
+pub struct TreeRecursiveWalker<'tree> {
+    cursor: &'tree mut TreeCursor<'tree>,
+    queue: VecDeque<Node<'tree>>,
+    root: Node<'tree>,
+}
+
+impl<'tree> Iterator for TreeRecursiveWalker<'tree> {
+    type Item = Node<'tree>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let current = self.cursor.node();
+
+        if current != self.root && self.cursor.goto_next_sibling() {
+            self.queue.push_back(current);
+            return Some(self.cursor.node());
+        }
+
+        while let Some(queued) = self.queue.pop_front() {
+            self.cursor.reset(queued);
+
+            if !self.cursor.goto_first_child() {
+                continue;
+            }
+
+            return Some(self.cursor.node());
+        }
+
+        None
     }
 }
 

--- a/highlighter/src/tree_cursor.rs
+++ b/highlighter/src/tree_cursor.rs
@@ -1,3 +1,5 @@
+use std::collections::VecDeque;
+
 use crate::tree_sitter::Node;
 use crate::{Layer, Syntax};
 
@@ -127,5 +129,53 @@ impl<'tree> Iterator for ChildIter<'_, 'tree> {
         } else {
             self.cursor.goto_next_sibling().then(|| self.cursor.node())
         }
+    }
+}
+
+impl<'cursor, 'tree> IntoIterator for &'cursor mut TreeCursor<'tree> {
+    type Item = Node<'tree>;
+    type IntoIter = TreeRecursiveWalker<'cursor, 'tree>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        let mut queue = VecDeque::new();
+        let root = self.node();
+        queue.push_back(root.clone());
+
+        TreeRecursiveWalker {
+            cursor: self,
+            queue,
+            root,
+        }
+    }
+}
+
+pub struct TreeRecursiveWalker<'cursor, 'tree> {
+    cursor: &'cursor mut TreeCursor<'tree>,
+    queue: VecDeque<Node<'tree>>,
+    root: Node<'tree>,
+}
+
+impl<'tree> Iterator for TreeRecursiveWalker<'_, 'tree> {
+    type Item = Node<'tree>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let current = self.cursor.node();
+
+        if current != self.root && self.cursor.goto_next_sibling() {
+            self.queue.push_back(current);
+            return Some(self.cursor.node());
+        }
+
+        while let Some(queued) = self.queue.pop_front() {
+            self.cursor.cursor.reset(queued);
+
+            if !self.cursor.goto_first_child() {
+                continue;
+            }
+
+            return Some(self.cursor.node());
+        }
+
+        None
     }
 }

--- a/highlighter/src/tree_cursor.rs
+++ b/highlighter/src/tree_cursor.rs
@@ -167,7 +167,7 @@ impl<'tree> Iterator for TreeRecursiveWalker<'_, 'tree> {
         }
 
         while let Some(queued) = self.queue.pop_front() {
-            self.cursor.cursor.reset(queued);
+            self.cursor.cursor.reset(&queued);
 
             if !self.cursor.goto_first_child() {
                 continue;


### PR DESCRIPTION
This code was originally in https://github.com/helix-editor/helix/pull/6198, and is now getting submitted separately here

* Adds an iterator for a TreeCursor which walks the subtree starting at the cursor's node.
* Adds `Node::is_contained_within` which returns true if the node's byte range is a proper subset of the input byte range.
* Adds `TreeCursor::reset` which resets the cursor to the given node
