### PR TITLE
feat: Add `injection.parent-layer` property

### DIFF
--- a/fixtures/highlighter/rust_doc_comment.rs
+++ b/fixtures/highlighter/rust_doc_comment.rs
@@ -6,6 +6,29 @@
 // │ │╰─ comment
 // │ ╰─ comment comment
 // ╰─ comment
+   ///
+// ┡┛╿╰─ comment
+// │ ╰─ comment comment
+// ╰─ comment
+   /// ```
+// ┡┛╿┡━━┛╰─ comment markup.raw.block
+// │ │╰─ comment markup.raw.block punctuation.bracket
+// │ ╰─ comment comment
+// ╰─ comment
+   /// fn foo()
+// ┡┛╿╿┡┛╿┡━┛┡┛╰─ comment markup.raw.block
+// │ │││ ││  ╰─ comment markup.raw.block punctuation.bracket
+// │ │││ │╰─ comment markup.raw.block function
+// │ │││ ╰─ comment markup.raw.block
+// │ ││╰─ comment markup.raw.block keyword.function
+// │ │╰─ comment markup.raw.block
+// │ ╰─ comment comment
+// ╰─ comment
+   /// ```
+// ┡┛╿┡━━┛╰─ comment markup.raw.block
+// │ │╰─ comment markup.raw.block punctuation.bracket
+// │ ╰─ comment comment
+// ╰─ comment
    /// **foo
 // ┡┛╿╿┡┛┗━┹─ comment markup.bold
 // │ ││╰─ comment markup.bold punctuation.bracket

--- a/test-grammars/markdown/injections.scm
+++ b/test-grammars/markdown/injections.scm
@@ -5,6 +5,15 @@
   (#set! injection.include-unnamed-children))
 
 (fenced_code_block
+  (fenced_code_block_delimiter)
+  (block_continuation)
+  (code_fence_content) @injection.content
+  (fenced_code_block_delimiter)
+  (#set! injection.language injection.parent-layer)
+  (#set! injection.include-unnamed-children)
+  (#any-of? injection.parent-layer "rust"))
+
+(fenced_code_block
   (info_string
     (language) @injection.language)
   (code_fence_content) @injection.content (#set! injection.include-unnamed-children))


### PR DESCRIPTION
This was originally brought up in https://github.com/helix-editor/helix/pull/13116#pullrequestreview-2688251614

When injecting markdown into the documentation comments of a language, we want the default code block to be the same as the language itself.

So in this Gleam file, with `///` being documentation comments we want the default value of the code block to also have the Gleam language injection, as opposed to usually when there would not be any injection at all if there is no info string:

````gleam
/// Markdown is injected into these comments
/// ```
/// fn foo()
/// ```
fn foo()
````

It's possible to do this by introducing a bunch of `markdown` languages that `; inherits markdown` scopes, but instead of doing that this PR allows for a more generic way of doing this.

It introduces the `injection.parent-layer` property which can be set like this:

```scheme
(#set! injection.language injection.parent-layer)
```

This will set the injection language to be whatever is the parent layer of this language, if it's injected.

Using the `#any-of? injection.parent-layer` predicate you are also able to only allow this for specific languages:

```scheme
(#set! injection.language injection.parent-layer)
(#any-of? injection.parent-layer "gleam" "zig")
```

The above will have this injection effect only for the `"gleam"` and `"zig"` language. This is necessary as we want to control which languages have this power. Without it, we would see the default injection for code block without info strings in Markdown be the Markdown language itself, which we want to avoid.

----

To test this in Helix, add this query at the start of the file (before the `(info_string (language))` injection) in `runtime/queries/markdown/injections.scm`:

```scheme
(fenced_code_block
  (fenced_code_block_delimiter)
  (block_continuation)
  (code_fence_content) @injection.content
  (fenced_code_block_delimiter)
  (#set! injection.language injection.parent-layer)
  (#set! injection.include-unnamed-children)
  (#any-of? injection.parent-layer "gleam"))
```

Example file for testing:

```gleam
/// *Inline markdown*
///
/// ````javascript
/// function main() {}
/// ````
///
/// ``````
/// fn main() {}
/// /// *Inline markdown*
/// ///
/// /// `````
/// /// /// *Inline markdown*
/// /// ///
/// /// /// ````javascript
/// /// /// function main() {}
/// /// /// ````
/// /// ///
/// /// /// ````
/// /// /// fn main() {}
/// /// /// /// *Inline markdown*
/// /// /// ///
/// /// /// /// ```
/// /// /// /// fn main() {}
/// /// /// /// ```
/// /// /// fn main() {}
/// /// /// ````
/// /// fn main() {}
/// /// `````
/// fn main() {}
/// ``````
fn main() {}
```

Note: Immediately this will be useful for Gleam in helix, and also [Zig soon](https://github.com/tree-sitter-grammars/tree-sitter-zig/pull/10). Rust won't make use of this because it requires a custom language (such as injecting the `rust` language into markdown code block when the `(info_string)` is         `edition2024`)
