### PR TITLE
Remove unused dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -85,12 +85,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cov-mark"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0570650661aa447e7335f1d5e4f499d8e58796e617bedc9267d971e51c8b49d4"
-
-[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -565,7 +559,6 @@ name = "tree-house"
 version = "0.3.0"
 dependencies = [
  "arc-swap",
- "cov-mark",
  "hashbrown",
  "indexmap",
  "kstring",

--- a/highlighter/Cargo.toml
+++ b/highlighter/Cargo.toml
@@ -28,7 +28,6 @@ pretty_assertions = { version = "1.4.0", optional = true }
 kstring = "2.0"
 
 [dev-dependencies]
-cov-mark = "2.0.0"
 indexmap = "2.5.0"
 skidder = { path = "../skidder" }
 


### PR DESCRIPTION
`cov-mark` is added as a dependency but I can't see its usage anywhere. I assume it is safe to remove.