### PR TITLE
feat: Add support for loading `tree-sitter-language` grammars

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -582,7 +582,14 @@ dependencies = [
  "regex-cursor",
  "ropey",
  "thiserror",
+ "tree-sitter-language",
 ]
+
+[[package]]
+name = "tree-sitter-language"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4013970217383f67b18aef68f6fb2e8d409bc5755227092d32efb0422ba24b8"
 
 [[package]]
 name = "twox-hash"

--- a/bindings/Cargo.toml
+++ b/bindings/Cargo.toml
@@ -11,12 +11,14 @@ rust-version = "1.76.0"
 
 [features]
 ropey = ["dep:ropey"]
+tree-sitter-language = ["dep:tree-sitter-language"]
 
 [dependencies]
 ropey = { version = "1.6", default-features = false, optional=true }
 regex-cursor = "0.1.5"
 libloading = "0.8"
 thiserror = "2.0"
+tree-sitter-language = { version = "0.1.5", optional = true }
 
 [build-dependencies]
 cc = "1.0"


### PR DESCRIPTION
Hi!

I'd love to be able to use `tree-house` as a highlighter for a custom presentation language I'm working on, but I'm not able to do so without the ability to load `tree-sitter` grammars in from crates. This PR gives `tree-house-bindings` the ability to do that.