### PR TITLE
Make grammar::Error more verbose.

### DIFF
--- a/bindings/src/grammar.rs
+++ b/bindings/src/grammar.rs
@@ -89,13 +89,13 @@ impl TryFrom<LanguageFn> for Grammar {
 
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
-    #[error("Error opening dynamic library {path:?}")]
+    #[error("Error opening dynamic library {path:?}: {err}")]
     DlOpen {
         #[source]
         err: libloading::Error,
         path: PathBuf,
     },
-    #[error("Failed to load symbol {symbol}")]
+    #[error("Failed to load symbol {symbol}: {err}")]
     DlSym {
         #[source]
         err: libloading::Error,


### PR DESCRIPTION
The carried `libloading::Error` is useful to debug actual issues occurring on dependent projects — I had to adapt a bit of code in kak-tree-sitter to pinpoint an issue while loading grammars with the wrong symbol (I was still trying to read tree_sitter_<lang> while the API of tree-house sets the prefix on its own), and I could have seen that right away if the {err} was present in the Display impl.

[Context](https://git.sr.ht/~hadronized/kak-tree-sitter/commit/abfeefe4597a57af096f53e689bb354c349f4fbd).