### PR TITLE
support using `; extends` in a new read_query_extends fn

### DIFF
--- a/highlighter/src/config.rs
+++ b/highlighter/src/config.rs
@@ -45,7 +45,12 @@ impl LanguageConfig {
 static INHERITS_REGEX: Lazy<Regex> =
     Lazy::new(|| Regex::new(r";+\s*inherits\s*:?\s*([a-z_,()-]+)\s*").unwrap());
 
-/// reads a query by invoking `read_query_text`, handles any `inherits` directives
+static EXTENDS_REGEX: Lazy<Regex> = Lazy::new(|| Regex::new(r";+\s*extends\s*").unwrap());
+
+/// reads a query by invoking `read_query_text`, handles any `inherits` directives.
+///
+/// if you need to also handle `extends` directives, you can use the [`read_query_extends`]
+/// function.
 pub fn read_query(language: &str, mut read_query_text: impl FnMut(&str) -> String) -> String {
     fn read_query_impl(language: &str, read_query_text: &mut impl FnMut(&str) -> String) -> String {
         let query = read_query_text(language);
@@ -69,6 +74,53 @@ pub fn read_query(language: &str, mut read_query_text: impl FnMut(&str) -> Strin
             .into_owned()
     }
     read_query_impl(language, &mut read_query_text)
+}
+
+/// gets a list of queries in priority order from highest to lowest by invoking
+/// `read_lang_queries`, handles any `extends` and `inherits` directives.
+///
+/// this function is very similar to [`read_query`], however it also handles `extends`
+/// directives in addition to `inherits`.
+pub fn read_query_extends<I>(language: &str, mut read_lang_queries: impl FnMut(&str) -> I) -> String
+where
+    I: Iterator<Item = String>,
+{
+    fn read_query_impl<I>(read_lang_queries: &mut impl FnMut(&str) -> I, mut queries: I) -> String
+    where
+        I: Iterator<Item = String>,
+    {
+        let Some(mut query) = queries.next() else {
+            return String::new();
+        };
+
+        // replace all "; extends" with the queries of the current language, one precedence level up
+        if let Some(m) = EXTENDS_REGEX.find(&query) {
+            let q = read_query_impl(read_lang_queries, queries);
+            query.replace_range(m.range(), &q);
+        }
+
+        // replaces all "; inherits <language>(,<language>)*" with the queries of the given language(s)
+        INHERITS_REGEX
+            .replace_all(&query, |captures: &regex::Captures| {
+                captures[1]
+                    .split(',')
+                    .fold(String::new(), |mut output, language| {
+                        let queries = read_lang_queries(language);
+                        // `write!` to a String cannot fail.
+                        write!(
+                            output,
+                            "\n{}\n",
+                            read_query_impl(&mut *read_lang_queries, queries)
+                        )
+                        .unwrap();
+                        output
+                    })
+            })
+            .into_owned()
+    }
+
+    let queries = read_lang_queries(language);
+    read_query_impl(&mut read_lang_queries, queries)
 }
 
 pub trait LanguageLoader {

--- a/highlighter/src/lib.rs
+++ b/highlighter/src/lib.rs
@@ -8,7 +8,7 @@ use std::hash::{Hash, Hasher};
 use std::time::Duration;
 use tree_sitter::{IncompatibleGrammarError, Node, Tree};
 
-pub use crate::config::{read_query, LanguageConfig, LanguageLoader};
+pub use crate::config::{read_query, read_query_extends, LanguageConfig, LanguageLoader};
 pub use crate::injections_query::{InjectionLanguageMarker, InjectionsQuery};
 use crate::parse::LayerUpdateFlags;
 pub use crate::query_iter::{CapturedMatch, QueryMatchIter, QueryMatchIterEvent};


### PR DESCRIPTION
makes a new function `read_query_extends`, that is similar to `read_query`, but it takes a closure that returns an Iterator of Strings in order of priority, and uses that to handle `; extends` directives, going down one level of priority for each directive.

the `; extends` directive makes it, so that you can define custom queries without having to copy all of the existing ones, by just doing `; extends` in your file and then writing your own custom queries.

this is the part on the tree-house side to address https://github.com/helix-editor/helix/issues/14950. i have also made a branch on helix, that shows this in use: https://github.com/m4rch3n1ng/helix/tree/queries-extend.

(note: i didn't change what `read_query` does and instead added a new function for backwards compatability)