### PR TITLE
[bindings] Add Redox OS support to portable endian.h

### DIFF
--- a/bindings/vendor/src/portable/endian.h
+++ b/bindings/vendor/src/portable/endian.h
@@ -241,41 +241,36 @@
 #    define __BIG_ENDIAN BIG_ENDIAN
 
 
-static inline uint16_t htobe16(uint16_t x) {
-    if (__BYTE_ORDER == __LITTLE_ENDIAN) {
-        return __builtin_bswap16(x);
-    }
-
+inline uint16_t htobe16(uint16_t x) {
+#if __BYTE_ORDER == __LITTLE_ENDIAN
+    return __builtin_bswap16(x);
+#else
     return x;
+#endif
 }
 
-static inline uint16_t be16toh(uint16_t x) {
-    return htobe16(x);
-}
+inline uint16_t be16toh(uint16_t x) { return htobe16(x); }
 
-static inline __uint32_t htobe32(uint32_t x) {
-    if (__BYTE_ORDER == __LITTLE_ENDIAN) {
-        return __builtin_bswap32(x);
-    }
-
+inline __uint32_t htobe32(uint32_t x) {
+#if __BYTE_ORDER == __LITTLE_ENDIAN
+    return __builtin_bswap32(x);
+#else
     return x;
+#endif
 }
 
-static inline uint32_t be32toh(uint32_t x) {
-    return htobe32(x);
-}
+inline uint32_t be32toh(uint32_t x) { return htobe32(x); }
 
-static inline __uint64_t htobe64(uint64_t x) {
-    if (__BYTE_ORDER == __LITTLE_ENDIAN) {
-        return __builtin_bswap64(x);
-    }
-
+inline __uint64_t htobe64(uint64_t x) {
+#if __BYTE_ORDER == __LITTLE_ENDIAN
+    return __builtin_bswap64(x);
+#else
     return x;
+#endif
 }
 
-static inline uint64_t be64toh(uint64_t x) {
-    return htobe64(x);
-}
+inline uint64_t be64toh(uint64_t x) { return htobe64(x); }
+
 #else
 
 #    error platform not supported

--- a/bindings/vendor/src/portable/endian.h
+++ b/bindings/vendor/src/portable/endian.h
@@ -232,6 +232,50 @@
 #    define le32toh(x) ENDIAN_LE32(x)
 #    define le64toh(x) ENDIAN_LE64(x)
 
+#elif defined(__redox__)
+
+#    include <endian.h>
+
+#    define __BYTE_ORDER BYTE_ORDER
+#    define __LITTLE_ENDIAN LITTLE_ENDIAN
+#    define __BIG_ENDIAN BIG_ENDIAN
+
+
+static inline uint16_t htobe16(uint16_t x) {
+    if (__BYTE_ORDER == __LITTLE_ENDIAN) {
+        return __builtin_bswap16(x);
+    }
+
+    return x;
+}
+
+static inline uint16_t be16toh(uint16_t x) {
+    return htobe16(x);
+}
+
+static inline __uint32_t htobe32(uint32_t x) {
+    if (__BYTE_ORDER == __LITTLE_ENDIAN) {
+        return __builtin_bswap32(x);
+    }
+
+    return x;
+}
+
+static inline uint32_t be32toh(uint32_t x) {
+    return htobe32(x);
+}
+
+static inline __uint64_t htobe64(uint64_t x) {
+    if (__BYTE_ORDER == __LITTLE_ENDIAN) {
+        return __builtin_bswap64(x);
+    }
+
+    return x;
+}
+
+static inline uint64_t be64toh(uint64_t x) {
+    return htobe64(x);
+}
 #else
 
 #    error platform not supported

--- a/bindings/vendor/src/portable/endian.h
+++ b/bindings/vendor/src/portable/endian.h
@@ -236,40 +236,40 @@
 
 #    include <endian.h>
 
-#    define __BYTE_ORDER BYTE_ORDER
-#    define __LITTLE_ENDIAN LITTLE_ENDIAN
-#    define __BIG_ENDIAN BIG_ENDIAN
+// #    define __BYTE_ORDER BYTE_ORDER
+// #    define __LITTLE_ENDIAN LITTLE_ENDIAN
+// #    define __BIG_ENDIAN BIG_ENDIAN
 
 
-inline uint16_t htobe16(uint16_t x) {
-#if __BYTE_ORDER == __LITTLE_ENDIAN
-    return __builtin_bswap16(x);
-#else
-    return x;
-#endif
-}
+// inline uint16_t htobe16(uint16_t x) {
+// #if __BYTE_ORDER == __LITTLE_ENDIAN
+//     return __builtin_bswap16(x);
+// #else
+//     return x;
+// #endif
+// }
 
-inline uint16_t be16toh(uint16_t x) { return htobe16(x); }
+// inline uint16_t be16toh(uint16_t x) { return htobe16(x); }
 
-inline __uint32_t htobe32(uint32_t x) {
-#if __BYTE_ORDER == __LITTLE_ENDIAN
-    return __builtin_bswap32(x);
-#else
-    return x;
-#endif
-}
+// inline __uint32_t htobe32(uint32_t x) {
+// #if __BYTE_ORDER == __LITTLE_ENDIAN
+//     return __builtin_bswap32(x);
+// #else
+//     return x;
+// #endif
+// }
 
-inline uint32_t be32toh(uint32_t x) { return htobe32(x); }
+// inline uint32_t be32toh(uint32_t x) { return htobe32(x); }
 
-inline __uint64_t htobe64(uint64_t x) {
-#if __BYTE_ORDER == __LITTLE_ENDIAN
-    return __builtin_bswap64(x);
-#else
-    return x;
-#endif
-}
+// inline __uint64_t htobe64(uint64_t x) {
+// #if __BYTE_ORDER == __LITTLE_ENDIAN
+//     return __builtin_bswap64(x);
+// #else
+//     return x;
+// #endif
+// }
 
-inline uint64_t be64toh(uint64_t x) { return htobe64(x); }
+// inline uint64_t be64toh(uint64_t x) { return htobe64(x); }
 
 #else
 

--- a/bindings/vendor/src/portable/endian.h
+++ b/bindings/vendor/src/portable/endian.h
@@ -26,7 +26,8 @@
     defined(__MSYS__) || \
     defined(__EMSCRIPTEN__) || \
     defined(__wasi__) || \
-    defined(__wasm__)
+    defined(__wasm__) || \
+    defined(__redox__)
 
 #if defined(__NetBSD__)
 #define _NETBSD_SOURCE 1
@@ -231,45 +232,6 @@
 #    define le16toh(x) ENDIAN_LE16(x)
 #    define le32toh(x) ENDIAN_LE32(x)
 #    define le64toh(x) ENDIAN_LE64(x)
-
-#elif defined(__redox__)
-
-#    include <endian.h>
-
-// #    define __BYTE_ORDER BYTE_ORDER
-// #    define __LITTLE_ENDIAN LITTLE_ENDIAN
-// #    define __BIG_ENDIAN BIG_ENDIAN
-
-
-// inline uint16_t htobe16(uint16_t x) {
-// #if __BYTE_ORDER == __LITTLE_ENDIAN
-//     return __builtin_bswap16(x);
-// #else
-//     return x;
-// #endif
-// }
-
-// inline uint16_t be16toh(uint16_t x) { return htobe16(x); }
-
-// inline __uint32_t htobe32(uint32_t x) {
-// #if __BYTE_ORDER == __LITTLE_ENDIAN
-//     return __builtin_bswap32(x);
-// #else
-//     return x;
-// #endif
-// }
-
-// inline uint32_t be32toh(uint32_t x) { return htobe32(x); }
-
-// inline __uint64_t htobe64(uint64_t x) {
-// #if __BYTE_ORDER == __LITTLE_ENDIAN
-//     return __builtin_bswap64(x);
-// #else
-//     return x;
-// #endif
-// }
-
-// inline uint64_t be64toh(uint64_t x) { return htobe64(x); }
 
 #else
 


### PR DESCRIPTION
Redox OS uses Relibc, which provides <endian.h> declarations for htobeXX/beXXtoh functions.  
Adding __redox__ to the list of supported platforms avoids the #error "platform not supported"  
and allows linking against Relibc implementations.

Tested during Helix porting on Redox (see related issue/MR in Redox repo).